### PR TITLE
Create image if contentType Alias is vector graphic

### DIFF
--- a/src/Core/DefaultMappings/ImageMappings.cs
+++ b/src/Core/DefaultMappings/ImageMappings.cs
@@ -31,7 +31,7 @@ namespace YuzuDelivery.Umbraco.Core
         {
             if (source != null && source.ContentType != null)
             {
-                if (source.ContentType.Alias == "Image")
+                if (source.ContentType.Alias == "Image" || source.ContentType.Alias == "umbracoMediaVectorGraphics")
                     return imageFactory.CreateImage(source.Content);
                 if (source.ContentType.Alias == "File")
                     return imageFactory.CreateFile(source.Content);


### PR DESCRIPTION
Alternatively, one could create a separate vector converter instead of reusing the image converter. I prefer this approach because I want all my images to have the same properties anyway. I then handle 0 values on width and height on the definition side as vectors for media picker v3 doesn't have a width and height by default.