### PR TITLE
Fixes an issue where nested blocklists won't preview after an edit unless you refresh the window, either manually or through save and publish

### DIFF
--- a/src/BlockList/Web/UI/App_Plugins/YuzuBlockList/GridContentItem.js
+++ b/src/BlockList/Web/UI/App_Plugins/YuzuBlockList/GridContentItem.js
@@ -28,7 +28,7 @@
 function getCircularReplacer() {
     const seen = new WeakSet();
     return (key, value) => {
-        if (key == "$block")
+        if (key === "$block")
             return null;
         if (typeof value === "object" && value !== null) {
             if (seen.has(value)) {


### PR DESCRIPTION
Fixes circular dependencies and ignores properties with the key '$block'.