### PR TITLE
Make package manifests case sensitive

### DIFF
--- a/src/BlockList/Web/UI/App_Plugins/YuzuBlockList/package.manifest
+++ b/src/BlockList/Web/UI/App_Plugins/YuzuBlockList/package.manifest
@@ -1,10 +1,10 @@
 {   
-	css: [
-		'~/App_Plugins/YuzuBlockList/GridSection.css'
+	"css": [
+		"~/App_Plugins/YuzuBlockList/GridSection.css"
     ],
-	javascript: [
-		"~/app_plugins/YuzuBlockList/GridContentColumnsSettingsController.js",
-		"~/app_plugins/YuzuBlockList/GridContentItem.js",
-		"~/app_plugins/YuzuBlockList/GridContentSection.js"
+	"javascript": [
+		"~/App_Plugins/YuzuBlockList/GridContentColumnsSettingsController.js",
+		"~/App_Plugins/YuzuBlockList/GridContentItem.js",
+		"~/App_Plugins/YuzuBlockList/GridContentSection.js"
 	]
 }

--- a/src/Core/Web/UI/App_Plugins/YuzuBackofficeCss/package.manifest
+++ b/src/Core/Web/UI/App_Plugins/YuzuBackofficeCss/package.manifest
@@ -1,5 +1,5 @@
 {   
-	css: [
-		'~/_client/styles/backoffice.css'
+	"css": [
+		"~/_client/styles/backoffice.css"
     ]
 }

--- a/src/Core/Web/UI/App_Plugins/YuzuDeliveryViewModelsBuilder/package.manifest
+++ b/src/Core/Web/UI/App_Plugins/YuzuDeliveryViewModelsBuilder/package.manifest
@@ -1,8 +1,8 @@
 ﻿{
   "javascript": [
-    "~/app_plugins/YuzuDeliveryViewModelsBuilder/backoffice/YuzuDeliveryViewModelsBuilder/yuzuDashboardController.js"
+    "~/App_Plugins/YuzuDeliveryViewModelsBuilder/backoffice/YuzuDeliveryViewModelsBuilder/yuzuDashboardController.js"
   ],
   "css": [
-    "~/app_plugins/YuzuDeliveryViewModelsBuilder/yuzu.css"
-  ],
+    "~/App_Plugins/YuzuDeliveryViewModelsBuilder/yuzu.css"
+  ]
 }


### PR DESCRIPTION
The backoffice js and css bundler for umbraco cloud is case sensitive in regards to paths.  

This makes relevant paths respect casing of folder and file names